### PR TITLE
README.md fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class WcHello extends withComponent(withReact()) {
   }
   renderCallback({ props }) {
     return (
-      <ReactHello {...props} />
+      <ReactHello {...props}><slot/></ReactHello>
     );
   }
 }


### PR DESCRIPTION
In order to get the README example to work as stated, &lt;slot/&gt; must be rendered as a child of the React element. As someone new to skatejs/webcomponents, this threw me for a loop for a while; hoping this patch will prevent someone else from blocking on getting the example working.